### PR TITLE
Add Rank Ray finance dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# learning-ai
+# Learning AI Repository
+
+This repository contains various learning projects. Included is a simple Next.js finance dashboard for Rank Ray brand colors.
+
+## Rank Ray Finance App
+
+The `rankray-finance-app` folder contains a basic Next.js application with API routes for income, invoices and expenses. It demonstrates a minimal backend using Next.js API routes and a small dashboard UI using approximate Rank Ray branded colors.
+
+### Getting Started
+
+1. Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+2. Run the development server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser to view the dashboard.
+
+### Features
+
+- **Income**: View sample income entries.
+- **Invoices**: View sample invoices.
+- **Expenses**: View sample expenses.
+
+These pages fetch data from the corresponding API routes under `pages/api`.
+

--- a/rankray-finance-app/package.json
+++ b/rankray-finance-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rankray-finance",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "next": "13.4.19",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/rankray-finance-app/pages/_app.js
+++ b/rankray-finance-app/pages/_app.js
@@ -1,0 +1,5 @@
+import '@/styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/rankray-finance-app/pages/api/expenses.js
+++ b/rankray-finance-app/pages/api/expenses.js
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+  const data = [
+    { id: 1, description: 'Rent', amount: 1000 },
+    { id: 2, description: 'Utilities', amount: 300 }
+  ]
+  res.status(200).json(data)
+}

--- a/rankray-finance-app/pages/api/income.js
+++ b/rankray-finance-app/pages/api/income.js
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+  const data = [
+    { id: 1, source: 'Salary', amount: 5000 },
+    { id: 2, source: 'Freelance', amount: 1200 }
+  ]
+  res.status(200).json(data)
+}

--- a/rankray-finance-app/pages/api/invoices.js
+++ b/rankray-finance-app/pages/api/invoices.js
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+  const data = [
+    { id: 1, description: 'Website project', amount: 2000 },
+    { id: 2, description: 'Consulting', amount: 1500 }
+  ]
+  res.status(200).json(data)
+}

--- a/rankray-finance-app/pages/expenses.js
+++ b/rankray-finance-app/pages/expenses.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export default function Expenses() {
+  const [expenses, setExpenses] = useState([])
+  useEffect(() => {
+    fetch('/api/expenses')
+      .then(res => res.json())
+      .then(setExpenses)
+  }, [])
+
+  return (
+    <div>
+      <h1>Expenses</h1>
+      <ul>
+        {expenses.map(exp => (
+          <li key={exp.id}>{exp.description}: ${exp.amount}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/rankray-finance-app/pages/income.js
+++ b/rankray-finance-app/pages/income.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export default function Income() {
+  const [income, setIncome] = useState([])
+  useEffect(() => {
+    fetch('/api/income')
+      .then(res => res.json())
+      .then(setIncome)
+  }, [])
+
+  return (
+    <div>
+      <h1>Income</h1>
+      <ul>
+        {income.map(item => (
+          <li key={item.id}>{item.source}: ${item.amount}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/rankray-finance-app/pages/index.js
+++ b/rankray-finance-app/pages/index.js
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <nav className="navbar">
+        <Link href="/income">Income</Link>
+        <Link href="/invoices">Invoices</Link>
+        <Link href="/expenses">Expenses</Link>
+      </nav>
+      <main>
+        <h1>Rank Ray Finance Dashboard</h1>
+        <p>Welcome to your finance dashboard. Use the links above to manage your finances.</p>
+      </main>
+    </div>
+  )
+}

--- a/rankray-finance-app/pages/invoices.js
+++ b/rankray-finance-app/pages/invoices.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export default function Invoices() {
+  const [invoices, setInvoices] = useState([])
+  useEffect(() => {
+    fetch('/api/invoices')
+      .then(res => res.json())
+      .then(setInvoices)
+  }, [])
+
+  return (
+    <div>
+      <h1>Invoices</h1>
+      <ul>
+        {invoices.map(inv => (
+          <li key={inv.id}>{inv.description}: ${inv.amount}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/rankray-finance-app/styles/globals.css
+++ b/rankray-finance-app/styles/globals.css
@@ -1,0 +1,19 @@
+:root {
+  --primary-color: #4B0082;
+  --secondary-color: #00bcd4;
+}
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: var(--secondary-color);
+  color: #333;
+}
+.navbar {
+  background: var(--primary-color);
+  padding: 1rem;
+}
+.navbar a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- add a Next.js finance dashboard under `rankray-finance-app`
- provide API routes for income, invoices and expenses
- implement basic pages to fetch and display those records
- add simple styling with Rank Ray themed colors
- update repository README with instructions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd rankray-finance-app && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865ea59f470832cbedb8a9cc2f1f734